### PR TITLE
Fix

### DIFF
--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -15,6 +15,6 @@
   </loadBefore>
   <loadAfter>
   </loadAfter>
-  <manifestUri>https://raw.githubusercontent.com/pardeike/HarmonyRimWorld/v1.1.0.0/About/Manifest.xml</manifestUri>
+  <manifestUri>https://raw.githubusercontent.com/pardeike/HarmonyRimWorld/latest/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUri>
 </Manifest>

--- a/About/Manifest.xml
+++ b/About/Manifest.xml
@@ -15,6 +15,6 @@
   </loadBefore>
   <loadAfter>
   </loadAfter>
-  <manifestUri>https://raw.githubusercontent.com/pardeike/HarmonyRimWorld/master/About/Manifest.xml</manifestUri>
+  <manifestUri>https://raw.githubusercontent.com/pardeike/HarmonyRimWorld/v1.1.0.0/About/Manifest.xml</manifestUri>
   <downloadUri>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUri>
 </Manifest>


### PR DESCRIPTION
This change along with the ["latest" Tag Action](https://github.com/marketplace/actions/latest-tag) will make fluffy's mod manager compare the version number with the Manifest.xml in the latest release instead of the Manifest.xml in the master repo. 