### PR TITLE
Add TweakValue to disable stack trace optimization.

### DIFF
--- a/Source/ExceptionAnalyser.cs
+++ b/Source/ExceptionAnalyser.cs
@@ -5,12 +5,18 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using LudeonTK;
 using UnityEngine;
+using JetBrains.Annotations;
 
 namespace HarmonyMod
 {
 	public static class ExceptionTools
 	{
+		[TweakValue("_Harmony")]
+		[UsedImplicitly]
+		public static bool DisableStackTraceCaching;
+
 		public static readonly AccessTools.FieldRef<StackTrace, StackTrace[]> captured_traces = AccessTools.FieldRefAccess<StackTrace, StackTrace[]>("captured_traces");
 		public static readonly AccessTools.FieldRef<StackFrame, string> internalMethodName = AccessTools.FieldRefAccess<StackFrame, string>("internalMethodName");
 		public static readonly AccessTools.FieldRef<StackFrame, long> methodAddress = AccessTools.FieldRefAccess<StackFrame, long>("methodAddress");
@@ -56,6 +62,8 @@ namespace HarmonyMod
 			_ = sb.AddHarmonyFrames(trace);
 			var stacktrace = sb.ToString();
 			hash = stacktrace.GetHashCode();
+			if (DisableStackTraceCaching)
+				return stacktrace;
 			var hashRef = $"[Ref {hash:X}]";
 			if (forceRefresh)
 				return $"{hashRef}\n{stacktrace}";


### PR DESCRIPTION
Hi,

I can see that in ~the latest~ a recent version of Harmony you have introduced a feature where stack trace strings are cached and subsequent extractions ommit the stack trace, instead giving a reference to the original.
While I understand the intention behind this change I find it rather frustrating as a mod developer.

When I am trying to debug rendering code (i.e. every frame, not every tick) or code that outputs hundreds of errors at once, the reference system just serves as obsfucation. In some cases (such as when working with rendering), the in-game log fills up so fast that I am forced to open the log file and Ctrl+F just to find the full stack trace.

This PR adds a TweakValue that disables the caching feature when it is enabled. Additionally when disabled, the `[XXX Ref]` is no longer prepended to the stack trace.
The TweakValue is disabled by default so standard behaviour does not change.

Thank you for your consideration.